### PR TITLE
Truncate error messages to fit DB columns

### DIFF
--- a/api/v3/GoogleCivicInformation.php
+++ b/api/v3/GoogleCivicInformation.php
@@ -384,9 +384,9 @@ function electoral_district_address_errors($districts, $addressId) {
   //Retain the error, so we can filter out the address on future runs until it's corrected
   $address_error_create = civicrm_api3('CustomValue', 'create', [
     'entity_id' => $addressId,
-    'custom_electoral_status:Error Code' => $districts['error']['code'],
-    'custom_electoral_status:Error Reason' => $districts['error']['errors'][0]['reason'],
-    'custom_electoral_status:Error Message' => $districts['error']['message'],
+    'custom_electoral_status:Error Code' => substr($districts['error']['code'], 0, 11),
+    'custom_electoral_status:Error Reason' => substr($districts['error']['errors'][0]['reason'], 0, 255),
+    'custom_electoral_status:Error Message' => substr($districts['error']['message'], 0, 255),
   ]);
 }
 


### PR DESCRIPTION
I just ran into an error message from Google that was over the 255 char length of the column in our custom value table.