### PR TITLE
Small changes to remove error messages on settings form

### DIFF
--- a/CRM/Admin/Form/Setting/Electoral.php
+++ b/CRM/Admin/Form/Setting/Electoral.php
@@ -24,11 +24,11 @@ class CRM_Admin_Form_Setting_Electoral extends CRM_Admin_Form_Setting {
     $this->add('text', 'proPublicaCongressAPIKey', ts('ProPublica Congress API Key'), NULL);
 		$this->_location_types = CRM_Core_PseudoConstant::get('CRM_Core_DAO_Address', 'location_type_id');
 		$this->_location_types = array('Primary') + $this->_location_types;
-    $this->add('select', 'addressLocationType', ts('Address location for district lookup.'), 
+    $this->add('select', 'addressLocationType', ts('Address location for district lookup.'),
       $this->_location_types, FALSE, array('class' => 'crm-select2')
     );
     $this->add('select', 'includedStatesProvinces', ts('States included in API calls'),
-      CRM_Core_PseudoConstant::stateProvince(), FALSE, array('multiple' => 'multiple', 'class' => 'crm-select2')
+      CRM_Core_PseudoConstant::stateProvince(FALSE, TRUE), FALSE, array('multiple' => 'multiple', 'class' => 'crm-select2')
     );
     $this->addChainSelect('includedCounties', array('control_field' => 'includedStatesProvinces', 'data-callback' => 'civicrm/ajax/jqCounty', 'label' => "Counties included in the API calls", 'data-empty-prompt' => 'Choose state first', 'data-none-prompt' => '- N/A -', 'multiple' => TRUE, 'required' => FALSE, 'placeholder' => '- none -'));
     $this->add('text', 'includedCities', ts('Cities included in API Calls'), NULL);
@@ -42,7 +42,19 @@ class CRM_Admin_Form_Setting_Electoral extends CRM_Admin_Form_Setting {
 
     // export form elements
     $this->assign('elementNames', $this->getRenderableElementNames());
-    parent::buildQuickForm();
+
+    $this->addButtons([
+      [
+        'type' => 'next',
+        'name' => ts('Save'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+
   }
 
   /**

--- a/CRM/Admin/Form/Setting/Electoral.php
+++ b/CRM/Admin/Form/Setting/Electoral.php
@@ -19,6 +19,7 @@ class CRM_Admin_Form_Setting_Electoral extends CRM_Admin_Form_Setting {
   );
 
   function buildQuickForm() {
+    CRM_Core_Session::singleton()->pushUserContext(CRM_Utils_System::url('civicrm/admin/setting/electoral', 'reset=1'));
 
     $this->add('text', 'googleCivicInformationAPIKey', ts('Google Civic Information API Key'), NULL);
     $this->add('text', 'proPublicaCongressAPIKey', ts('ProPublica Congress API Key'), NULL);

--- a/settings/Electoral.setting.php
+++ b/settings/Electoral.setting.php
@@ -15,6 +15,7 @@ return array(
     'is_contact' => 0,
     'description' => 'Google Civic API Key',
     'help_text' => 'Add your registered Google Civic Information API Key for Open Civic Data API calls',
+    'html_type' => 'text',
   ),
   'proPublicaCongressAPIKey' => array(
     'group_name' => 'Electoral API settings',
@@ -27,6 +28,7 @@ return array(
     'is_contact' => 0,
     'description' => 'ProPublica Congress API Key',
     'help_text' => 'Add your registered ProPublica Congress API Key for API calls',
+    'html_type' => 'text',
   ),
   'addressLocationType' => array(
     'group_name' => 'Electoral API settings',
@@ -39,6 +41,7 @@ return array(
     'is_contact' => 0,
     'description' => 'Address location for district lookup.',
     'help_text' => 'Select the address location type to use when looking up a contact\'s districts.',
+    'html_type' => 'select',
   ),
   'includedStatesProvinces' => array(
     'group_name' => 'Electoral API settings',
@@ -51,6 +54,7 @@ return array(
     'is_contact' => 0,
     'description' => 'States and Provinces included in API calls',
     'help_text' => 'Add states and provinces to include in API scheduled jobs',
+    'html_type' => 'multiselect',
   ),
   'includedCounties' => array(
     'group_name' => 'Electoral API settings',
@@ -63,6 +67,7 @@ return array(
     'is_contact' => 0,
     'description' => 'Counties included in API calls',
     'help_text' => 'Add counties to include in API scheduled jobs',
+    'html_type' => 'multiselect',
   ),
   'includedCities' => array(
     'group_name' => 'Electoral API settings',
@@ -75,6 +80,7 @@ return array(
     'is_contact' => 0,
     'description' => 'Cities included in API calls',
     'help_text' => 'Add cities, comma separated, to include in API scheduled jobs',
+    'html_type' => 'text',
   ),
 );
 


### PR DESCRIPTION
The settings form was reporting multiple errors like this one, one for each settings field.


`User deprecated function: Deprecated function CRM_Admin_Form_Setting::getQuickFormType, use Settings fields html_type should be lower case - see https://docs.civicrm.org/dev/en/latest/framework/setting/ - this needs to be fixed for googleCivicInformationAPIKey. Array ( [civi.tag] => deprecated ) in CRM_Core_Error_Log->log() (line 69 of /var/www/d7civi47latest/sites/all/modules/civicrm/CRM/Core/Error/Log.php).
`