### PR TITLE
Fix for #19.

### DIFF
--- a/api/v3/GoogleCivicInformation.php
+++ b/api/v3/GoogleCivicInformation.php
@@ -84,7 +84,21 @@ function google_civic_information_country_districts($level, $limit, $update) {
           $divisionParts = explode(':', str_replace($countryDivision, '', $divisionKey));
           $divisionDistrict = $divisionParts[1];
         }
-        electoral_district_create_update($contactAddresses->contact_id, $level, $contactAddresses->state_province_id, NULL, NULL, NULL, $divisionDistrict);
+
+        if (!empty($division['officeIndices'])) {
+          foreach ($division['officeIndices'] as $officeIndex) {
+            if (in_array('legislatorUpperBody', $districts['offices'][$officeIndex]['roles'])) {
+              $chamber = 'upper';
+            }
+            else {
+              $chamber = 'lower';
+            }
+            electoral_district_create_update($contactAddresses->contact_id, $level, $contactAddresses->state_province_id, NULL, NULL, $chamber, $divisionDistrict);
+          }
+        }
+        else {
+          electoral_district_create_update($contactAddresses->contact_id, $level, $contactAddresses->state_province_id, NULL, NULL, NULL, $divisionDistrict);
+        }
       }
       $addressesDistricted++;
     }


### PR DESCRIPTION
This approach cycles through `$division['officeIndices']` as a kind of formality, considering that the google api structure is meant to allow multiple values here. But in fact, in the US, for `level="country"`, we should really expect only one value.  Anyway, all that just as a way of saying: the google api structure is complex, and I hope I'm getting this right.